### PR TITLE
Update for Responder changes in actix-web@4.0.0-beta3.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ xmltree = "0.10.2"
 hyper = {version = "0.14.2", optional = true }
 warp = { version = "0.3.0", optional = true }
 #actix-web = { version = "3.3.2", optional = true }
-actix-web = { version = "4.0.0-beta.1", optional = true }
+actix-web = { version = "4.0.0-beta.3", optional = true }
 
 [dev-dependencies]
 clap = "2.33.3"

--- a/src/actix.rs
+++ b/src/actix.rs
@@ -20,7 +20,7 @@ use std::task::{Context, Poll};
 use actix_web::client::PayloadError;
 use actix_web::{dev, Error, FromRequest, HttpRequest, HttpResponse};
 use bytes::Bytes;
-use futures::{future, future::ok, future::Ready, Stream};
+use futures::{future, Stream};
 use pin_project::pin_project;
 
 /// http::Request compatibility.
@@ -129,7 +129,7 @@ impl actix_web::Responder for DavResponse {
         let (parts, body) = self.0.into_parts();
         let mut builder = HttpResponse::build(parts.status);
         for (name, value) in parts.headers.into_iter() {
-            builder.header(name.unwrap(), value);
+            builder.append_header((name.unwrap(), value));
         }
         // I noticed that actix-web returns an empty chunked body
         // (\r\n0\r\n\r\n) and _no_ Transfer-Encoding header on

--- a/src/actix.rs
+++ b/src/actix.rs
@@ -122,10 +122,8 @@ impl From<http::Response<crate::body::Body>> for DavResponse {
 }
 
 impl actix_web::Responder for DavResponse {
-    type Error = Error;
-    type Future = Ready<Result<HttpResponse, Error>>;
 
-    fn respond_to(self, _req: &HttpRequest) -> Self::Future {
+    fn respond_to(self, _req: &HttpRequest) -> HttpResponse {
         use crate::body::{Body, BodyType};
 
         let (parts, body) = self.0.into_parts();
@@ -144,6 +142,6 @@ impl actix_web::Responder for DavResponse {
             BodyType::Empty => builder.body(""),
             b @ BodyType::AsyncStream(..) => builder.streaming(Body { inner: b }),
         };
-        ok(resp)
+        resp
     }
 }


### PR DESCRIPTION
The associated types in the actix_web::Responder trait no longer exist.