### PR TITLE
Return correct quota information for all directories

### DIFF
--- a/src/handle_props.rs
+++ b/src/handle_props.rs
@@ -630,8 +630,8 @@ impl PropWriter {
             _ => {},
         }
 
-        // if not "/", return for "used" just the size of this file/dir.
-        let used = if path.as_bytes() == b"/" {
+        // if not a folder, return for "used" just the size of this file.
+        let used = if meta.is_dir() {
             qc.q_used
         } else {
             meta.len()


### PR DESCRIPTION
Currently, correct quota information is returned only for root ('/') folder. However, there are cases when we mount a subdirectory of a webdav server as the cloud disk, and in such case the subdirectory becomes the root folder, and we expect to see the correct quota information on this disk.

Therefore, this PR modifies the `get_quota` logic so correct quota information is returned for all directories in additional to root one.