### PR TITLE
Fix path traversal vulnerability

### DIFF
--- a/src/davpath.rs
+++ b/src/davpath.rs
@@ -91,15 +91,6 @@ impl From<ParseError> for DavError {
     }
 }
 
-// a decoded segment can contain any value except '/' or '\0'
-fn valid_segment(src: &[u8]) -> Result<(), ParseError> {
-    let mut p = pct::percent_decode(src);
-    if p.any(|x| x == 0 || x == b'/') {
-        return Err(ParseError::InvalidPath);
-    }
-    Ok(())
-}
-
 // encode path segment with user-defined ENCODE_SET
 fn encode_path(src: &[u8]) -> Vec<u8> {
     pct::percent_encode(src, ENCODE_SET).to_string().into_bytes()
@@ -110,8 +101,8 @@ fn encode_path(src: &[u8]) -> Vec<u8> {
 // - make sure path is absolute
 // - remove query part (everything after ?)
 // - merge consecutive slashes
-// - process . and ..
 // - decode percent encoded bytes, fail on invalid encodings.
+// - process . and ..
 // - do not allow NUL or '/' in segments.
 fn normalize_path(rp: &[u8]) -> Result<Vec<u8>, ParseError> {
     // must consist of printable ASCII
@@ -138,10 +129,13 @@ fn normalize_path(rp: &[u8]) -> Result<Vec<u8>, ParseError> {
         Some(x) if *x == b'/' => true,
         _ => false,
     };
-    let segments = rawpath.split(|c| *c == b'/');
+    let segments: Vec<Vec<u8>> = rawpath
+        .split(|c| *c == b'/')
+        .map(|segment| pct::percent_decode(segment).collect())
+        .collect();
     let mut v: Vec<&[u8]> = Vec::new();
-    for segment in segments {
-        match segment {
+    for segment in &segments {
+        match &segment[..] {
             b"." | b"" => {},
             b".." => {
                 if v.len() < 2 {
@@ -151,8 +145,9 @@ fn normalize_path(rp: &[u8]) -> Result<Vec<u8>, ParseError> {
                 v.pop();
             },
             s => {
-                if let Err(e) = valid_segment(s) {
-                    Err(e)?;
+                // a decoded segment can contain any value except '/' or '\0'
+                if s.iter().any(|x| *x == 0 || *x == b'/') {
+                    return Err(ParseError::InvalidPath);
                 }
                 v.push(b"/");
                 v.push(s);
@@ -162,7 +157,7 @@ fn normalize_path(rp: &[u8]) -> Result<Vec<u8>, ParseError> {
     if isdir || v.is_empty() {
         v.push(b"/");
     }
-    Ok(v.iter().flat_map(|s| pct::percent_decode(s)).collect())
+    Ok(v.join(&b""[..]))
 }
 
 /// Comparision ignores any trailing slash, so /foo == /foo/


### PR DESCRIPTION
Hello,

Thanks for this Rust WebDAV implementation.

I found a path traversal vulnerability that you should be able to reproduce by running:
```shell
cargo run --example hyper
```

and then:
```shell
curl 'http://127.0.0.1:4918/%2e%2e/etc/passwd'
```

This PR proposes a way to handle this issue. I didn't read all this crate code, this patch may no be exhaustive.

I made a PR at https://github.com/messense/dav-server-rs/pull/10 too.