### PR TITLE
modifed for actix-web v4.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,8 @@ xmltree = "0.10.0"
 hyper = {version = "0.14.0", optional = true }
 warp = { version = "0.3.0", optional = true }
 #actix-web = { version = "3.3.2", optional = true }
-actix-web = { version = "4.0.0-beta.6", optional = true }
+# actix-web = { version = "4.0.0-beta.6", optional = true }
+actix-web = { version = "4.1.0", optional = true }
 
 [dev-dependencies]
 clap = "2.33.0"

--- a/src/actix.rs
+++ b/src/actix.rs
@@ -14,11 +14,12 @@
 //!
 use std::io;
 
+use std::ops::Deref;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use actix_web::error::PayloadError;
-use actix_web::{dev, Error, FromRequest, HttpRequest, HttpResponse};
+use actix_web::{body, dev, Error, FromRequest, HttpRequest, HttpResponse};
 use bytes::Bytes;
 use futures::{future, Stream};
 use pin_project::pin_project;
@@ -28,7 +29,7 @@ use pin_project::pin_project;
 /// Wraps `http::Request<DavBody>` and implements `actix_web::FromRequest`.
 pub struct DavRequest {
     pub request: http::Request<DavBody>,
-    prefix:      Option<String>,
+    prefix: Option<String>,
 }
 
 impl DavRequest {
@@ -39,7 +40,6 @@ impl DavRequest {
 }
 
 impl FromRequest for DavRequest {
-    type Config = ();
     type Error = Error;
     type Future = future::Ready<Result<DavRequest, Error>>;
 
@@ -83,19 +83,16 @@ impl http_body::Body for DavBody {
     fn poll_data(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<Self::Data, Self::Error>>>
-    {
+    ) -> Poll<Option<Result<Self::Data, Self::Error>>> {
         let this = self.project();
         match this.body.poll_next(cx) {
             Poll::Ready(Some(Ok(data))) => Poll::Ready(Some(Ok(data))),
-            Poll::Ready(Some(Err(err))) => {
-                Poll::Ready(Some(Err(match err {
-                    PayloadError::Incomplete(Some(err)) => err,
-                    PayloadError::Incomplete(None) => io::ErrorKind::BrokenPipe.into(),
-                    PayloadError::Io(err) => err,
-                    other => io::Error::new(io::ErrorKind::Other, format!("{:?}", other)),
-                })))
-            },
+            Poll::Ready(Some(Err(err))) => Poll::Ready(Some(Err(match err {
+                PayloadError::Incomplete(Some(err)) => err,
+                PayloadError::Incomplete(None) => io::ErrorKind::BrokenPipe.into(),
+                PayloadError::Io(err) => err,
+                other => io::Error::new(io::ErrorKind::Other, format!("{:?}", other)),
+            }))),
             Poll::Ready(None) => Poll::Ready(None),
             Poll::Pending => Poll::Pending,
         }
@@ -104,8 +101,7 @@ impl http_body::Body for DavBody {
     fn poll_trailers(
         self: Pin<&mut Self>,
         _cx: &mut Context,
-    ) -> Poll<Result<Option<http::HeaderMap>, Self::Error>>
-    {
+    ) -> Poll<Result<Option<http::HeaderMap>, Self::Error>> {
         Poll::Ready(Ok(None))
     }
 }
@@ -122,8 +118,8 @@ impl From<http::Response<crate::body::Body>> for DavResponse {
 }
 
 impl actix_web::Responder for DavResponse {
-
-    fn respond_to(self, _req: &HttpRequest) -> HttpResponse {
+    type Body = actix_web::body::BoxBody;
+    fn respond_to(self, _req: &HttpRequest) -> HttpResponse<Self::Body> {
         use crate::body::{Body, BodyType};
 
         let (parts, body) = self.0.into_parts();


### PR DESCRIPTION
I have updated `impl actix_web::Responder for DavResponse` for actix-web v4.1.0 and passed a build with `default` and `actix-compat` features.