### PR TITLE
Fix wrong XML format for `supportedlock` prop

### DIFF
--- a/src/handle_lock.rs
+++ b/src/handle_lock.rs
@@ -242,16 +242,20 @@ pub(crate) fn list_supportedlock(ls: Option<&Box<dyn DavLockSystem>>) -> Element
 
     let mut entry = Element::new2("D:lockentry");
     let mut scope = Element::new2("D:lockscope");
+    let mut ltype = Element::new2("D:locktype");
     scope.push_element(Element::new2("D:exclusive"));
-    scope.push_element(Element::new2("D:write"));
+    ltype.push_element(Element::new2("D:write"));
     entry.push_element(scope);
+    entry.push_element(ltype);
     elem.push_element(entry);
 
     let mut entry = Element::new2("D:lockentry");
     let mut scope = Element::new2("D:lockscope");
+    let mut ltype = Element::new2("D:locktype");
     scope.push_element(Element::new2("D:shared"));
-    scope.push_element(Element::new2("D:write"));
+    ltype.push_element(Element::new2("D:write"));
     entry.push_element(scope);
+    entry.push_element(ltype);
     elem.push_element(entry);
 
     elem


### PR DESCRIPTION
As per specification from http://www.webdav.org/specs/rfc4918.html#PROPERTY_supportedlock :

`PROPERTY_supportedlock` should have following format:
```
<D:supportedlock> 
  <D:lockentry> 
    <D:lockscope><D:exclusive/></D:lockscope> 
    <D:locktype><D:write/></D:locktype> 
  </D:lockentry> 
  <D:lockentry> 
    <D:lockscope><D:shared/></D:lockscope> 
    <D:locktype><D:write/></D:locktype> 
  </D:lockentry> 
</D:supportedlock> 
```

While that returned by `webdav-handler-rs` is:
```
<D:supportedlock> 
  <D:lockentry> 
    <D:lockscope><D:exclusive/><D:write/></D:lockscope> 
  </D:lockentry> 
  <D:lockentry> 
    <D:lockscope><D:shared/><D:write/></D:lockscope> 
  </D:lockentry> 
</D:supportedlock> 
```

This made webdav libraries like https://github.com/lookfirst/sardine and https://github.com/thegrizzlylabs/sardine-android report error on parsing XML returned by `webdav-handler-rs` (thus android apps using this library will fail to use webdav server of `webdav-handler-rs`).

This PR fixes the format by specfication.