### PR TITLE
Add `path` parameter to `get_quota` interface

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -228,7 +228,7 @@ pub trait DavFileSystem: Sync + Send + BoxCloneFs {
     ///
     /// The default implementation returns FsError::NotImplemented.
     #[allow(unused_variables)]
-    fn get_quota<'a>(&'a self) -> FsFuture<(u64, Option<u64>)> {
+    fn get_quota<'a>(&'a self, path: &'a DavPath) -> FsFuture<(u64, Option<u64>)> {
         notimplemented_fut!("get_quota`")
     }
 }

--- a/src/handle_props.rs
+++ b/src/handle_props.rs
@@ -614,7 +614,7 @@ impl PropWriter {
         // do lookup only once.
         match qc.q_state {
             0 => {
-                match self.fs.get_quota().await {
+                match self.fs.get_quota(path).await {
                     Err(e) => {
                         qc.q_state = 1;
                         return Err(e);


### PR DESCRIPTION
This PR adds `path` parameter to `DavFileSystem` trait's `get_quota` interface.

There are many cases when we use a folder like `/media` to export as webdav file root, but subfolders in `/media` are mounted with other filesystems:
```
/media -> rootfs
/media/dirA -> external ext4 system
/media/dirB -> external NTFS system
```

Currently, `get_quota` only collects quota information of root folder (the `/media`), even the client is querying quota information of path `/media/dirA` or `/media/dirB`. 

When using clients like `RaiDrive` in Windows, it will report disk usage just like normal physical disks, and we expect it to show the correct disk usage of drive `/media/dirA` or `/media/dirB` (maybe some TBs large), but not the `/media` from rootfs `(maybe just tens of GBs).

This PR adds a `path` parameter to `get_quota` interface, so its implementations could make use of the path information to return the correct quota information of corresponding disk.

This PR depends on #11 to return quota information for all directory path, instead of return only for root (`/`) path.