### PR TITLE
fix: remove nanoseconds in creationdate for Windows compatibility

### DIFF
--- a/src/handle_props.rs
+++ b/src/handle_props.rs
@@ -24,7 +24,7 @@ use crate::errors::*;
 use crate::fs::*;
 use crate::handle_lock::{list_lockdiscovery, list_supportedlock};
 use crate::ls::*;
-use crate::time::{systemtime_to_httpdate, systemtime_to_rfc3339};
+use crate::time::{systemtime_to_httpdate, systemtime_to_rfc3339_without_nanosecond};
 use crate::util::{MemBuffer, dav_xml_error};
 use crate::{DavInner, DavResult};
 
@@ -663,8 +663,9 @@ impl PropWriter {
                 pfx = "D";
                 match prop.name.as_str() {
                     "creationdate" => {
+                        // note: for Windows clients, nano seconds are not allowed.
                         if let Ok(time) = meta.created() {
-                            let tm = systemtime_to_rfc3339(time);
+                            let tm = systemtime_to_rfc3339_without_nanosecond(time);
                             return self.build_elem(docontent, pfx, prop, tm);
                         }
                         // use ctime instead - apache seems to do this.
@@ -675,7 +676,7 @@ impl PropWriter {
                                     time = mtime;
                                 }
                             }
-                            let tm = systemtime_to_rfc3339(time);
+                            let tm = systemtime_to_rfc3339_without_nanosecond(time);
                             return self.build_elem(docontent, pfx, prop, tm);
                         }
                     },

--- a/src/time.rs
+++ b/src/time.rs
@@ -51,10 +51,13 @@ pub(crate) fn systemtime_to_httpdate(t: SystemTime) -> String {
     v[0].to_str().unwrap().to_owned()
 }
 
-pub(crate) fn systemtime_to_rfc3339(t: SystemTime) -> String {
+pub(crate) fn systemtime_to_rfc3339_without_nanosecond(t: SystemTime) -> String {
     // 1996-12-19T16:39:57Z
     use time::format_description::well_known::Rfc3339;
-    time::OffsetDateTime::from(t).format(&Rfc3339)
+    time::OffsetDateTime::from(t)
+        .replace_nanosecond(0)
+        .ok()
+        .and_then(|x| x.format(&Rfc3339).ok())
         .unwrap_or("1970-01-01T00:00:00Z".into())
 }
 


### PR DESCRIPTION
For Windows 7 ~ 11, nanoseconds are not allowed.

I mean `Microsoft-WebDAV-MiniRedir`